### PR TITLE
Add example output section and remove sample images

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Repository Instructions
+
+- Use `pip install -r requirements.txt` to install dependencies.
+- Run `python Main_with_rotation.py --output_dir examples` after making changes to verify the script executes.
+- Record the results of these commands in your PR description.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This project searches a procedurally defined 4D color field for interesting 2D s
 Install dependencies with:
 
 ```bash
-pip install numpy matplotlib scipy
+pip install -r requirements.txt
 ```
 
 ## Usage
@@ -111,20 +111,13 @@ In this demo, we generate 10 evenly-spaced angles, giving a sense of the structu
 
 
 ---
+## Example Output
 
-Example output
+Sample output from a run of `Main_with_rotation.py`:
 
-From a single run you get:
-
-Coarse density map (int8) — shows where the data is most “active”.
-
-Origin slice (float32) — highest-scoring refined slice.
-
-Rotated slices — different angles around the perpendicular axis.
-
-
-These are saved as .png images for easy inspection.
-
+![Coarse Density Map](examples/coarse_density_map.png)
+![Origin Slice](examples/slice_origin.png)
+![Rotated Slice](examples/slice_rot_10deg.png)
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+matplotlib
+scipy


### PR DESCRIPTION
## Summary
- document project dependencies in `requirements.txt`
- add `AGENTS.md` with installation and run instructions
- add an "Example Output" section to the README linking to sample slices
- remove placeholder PNG images from the repository to keep it lightweight

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement numpy)*
- `python Main_with_rotation.py --output_dir examples` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_689c492acf5c8322bfcde5763d8ff7bf