### PR TITLE
Add demo script for generating example slices

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -1,0 +1,11 @@
+from Main_with_rotation import Config, main
+
+
+def run_demo():
+    """Generate example slices at reduced resolution and save to examples/ directory."""
+    cfg = Config(res_hi=256, num_rotated=4, output_dir="examples")
+    main(cfg)
+
+
+if __name__ == "__main__":
+    run_demo()

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,3 @@
+Example outputs will be generated here by running `demo.py`.
+
+Dependencies such as numpy, matplotlib, and scipy are required to run the pipeline.


### PR DESCRIPTION
## Summary
- add `demo.py` that runs the 4D slice pipeline at reduced resolution and writes outputs into `examples/`
- include placeholder README in `examples/` describing dependency requirements

## Testing
- `pip install numpy matplotlib scipy` *(fails: 403 Forbidden to proxy)*
- `python demo.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_689c492020248322b5aa9f5cecc458bf