### PR TITLE
Implement 4D slice sampling

### DIFF
--- a/dashifine/Main_with_rotation.py
+++ b/dashifine/Main_with_rotation.py
@@ -21,14 +21,71 @@ def orthonormalize(a: np.ndarray, b: np.ndarray, eps: float = 1e-8) -> Tuple[np.
     return a, b
 
 
-def rotate_plane(o: np.ndarray, a: np.ndarray, b: np.ndarray, axis: np.ndarray, angle_deg: float) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Rotate vector ``a`` toward ``axis`` by ``angle_deg`` degrees."""
+def rotate_plane_4d(
+    o: np.ndarray,
+    a: np.ndarray,
+    b: np.ndarray,
+    u: np.ndarray,
+    v: np.ndarray,
+    angle_deg: float,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Rotate ``o``, ``a`` and ``b`` in the plane spanned by ``u`` and ``v``.
+
+    The plane is defined by two (not necessarily normalised) vectors ``u`` and
+    ``v``.  Any component of the inputs lying in this plane is rotated by
+    ``angle_deg`` degrees while the orthogonal component is left unchanged.
+    """
+    u, v = orthonormalize(u, v)
     angle = np.deg2rad(angle_deg)
-    a = a / np.linalg.norm(a)
-    axis = axis / np.linalg.norm(axis)
-    a_rot = a * np.cos(angle) + axis * np.sin(angle)
-    b_new = b / np.linalg.norm(b)
-    return o, a_rot, b_new
+
+    def _rotate(x: np.ndarray) -> np.ndarray:
+        xu = np.dot(x, u)
+        xv = np.dot(x, v)
+        # Component orthogonal to the rotation plane remains unchanged
+        x_perp = x - xu * u - xv * v
+        xr = xu * np.cos(angle) - xv * np.sin(angle)
+        yr = xu * np.sin(angle) + xv * np.cos(angle)
+        return x_perp + xr * u + yr * v
+
+    return _rotate(o), _rotate(a), _rotate(b)
+
+
+def sample_slice_image(o: np.ndarray, a: np.ndarray, b: np.ndarray, res: int) -> np.ndarray:
+    """Map pixel coordinates of a slice image to 4D positions.
+
+    Parameters
+    ----------
+    o : np.ndarray
+        Slice origin in 4D.
+    a, b : np.ndarray
+        Basis vectors spanning the slice plane.
+    res : int
+        Resolution of the output image (assumed square).
+
+    Returns
+    -------
+    np.ndarray
+        Array of shape ``(res, res, 4)`` containing the 4D positions of each
+        pixel centre.
+    """
+    xs = np.linspace(-0.5, 0.5, res, endpoint=False, dtype=np.float32) + 0.5 / res
+    ys = np.linspace(-0.5, 0.5, res, endpoint=False, dtype=np.float32) + 0.5 / res
+    grid_x, grid_y = np.meshgrid(xs, ys, indexing="xy")
+    points = o + grid_x[..., None] * a + grid_y[..., None] * b
+    return points.astype(np.float32)
+
+
+def eval_field(points: np.ndarray) -> np.ndarray:
+    """Evaluate a simple CMYK-style field at 4D ``points``.
+
+    Distances to the four canonical basis vectors are converted to CMYK weights
+    via ``gelu`` and then mapped to RGB for visualisation.
+    """
+    centers = np.eye(4, dtype=np.float32)
+    dists = np.linalg.norm(points[..., None, :] - centers[None, None, :, :], axis=-1)
+    cmyk = gelu(1.0 - dists)
+    rgb = 1.0 - cmyk[..., :3]
+    return np.clip(rgb, 0.0, 1.0)
 
 
 def main(
@@ -44,13 +101,8 @@ def main(
     out_dir = Path(output_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    density = np.zeros((res_coarse, res_coarse), dtype=np.float32)
     density_path = out_dir / "coarse_density_map.png"
-    plt.imsave(density_path, density, cmap="gray")
-
-    origin = np.zeros((res_hi, res_hi, 3), dtype=np.float32)
     origin_path = out_dir / "slice_origin.png"
-    plt.imsave(origin_path, origin)
 
     paths = {"origin": str(origin_path), "coarse_density": str(density_path)}
 
@@ -59,10 +111,20 @@ def main(
     b = np.array([0.0, 1.0, 0.0, 0.0], dtype=np.float32)
     axis = np.array([0.0, 0.0, 1.0, 0.0], dtype=np.float32)
 
+    # Generate origin and coarse density maps using the field evaluation
+    coarse_points = sample_slice_image(o, a, b, res_coarse)
+    density = np.mean(eval_field(coarse_points), axis=-1)
+    plt.imsave(density_path, density, cmap="gray")
+
+    origin_points = sample_slice_image(o, a, b, res_hi)
+    origin_img = eval_field(origin_points)
+    plt.imsave(origin_path, origin_img)
+
     for i in range(num_rotated):
         angle = float(i) * 360.0 / max(num_rotated, 1)
-        _o, _a, _b = rotate_plane(o, a, b, axis, angle)
-        img = np.zeros((res_hi, res_hi, 3), dtype=np.float32)
+        _o, _a, _b = rotate_plane_4d(o, a, b, a, axis, angle)
+        points = sample_slice_image(_o, _a, _b, res_hi)
+        img = eval_field(points)
         rot_path = out_dir / f"slice_rot_{int(angle):+d}deg.png"
         plt.imsave(rot_path, img)
         paths[f"rot_{angle:+.1f}"] = str(rot_path)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -8,7 +8,6 @@ from dashifine.Main_with_rotation import (
     gelu,
     main,
     orthonormalize,
-    rotate_plane,
 )
 
 

--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -8,7 +8,7 @@ from dashifine.Main_with_rotation import (
     gelu,
     main,
     orthonormalize,
-    rotate_plane,
+    rotate_plane_4d,
 )
 
 
@@ -26,12 +26,13 @@ def test_orthonormalize_returns_unit_orthogonal():
     assert abs(np.dot(ao, bo)) < 1e-6
 
 
-def test_rotate_plane_produces_orthonormal():
+def test_rotate_plane_4d_produces_orthonormal():
     a = np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32)
     b = np.array([0.0, 1.0, 0.0, 0.0], dtype=np.float32)
     axis = np.array([0.0, 0.0, 1.0, 0.0], dtype=np.float32)
-    _, a_rot, b_new = rotate_plane(np.zeros(4, dtype=np.float32), a, b, axis, 90.0)
+    _, a_rot, b_new = rotate_plane_4d(np.zeros(4, dtype=np.float32), a, b, a, axis, 90.0)
     assert np.allclose(np.linalg.norm(a_rot), 1.0, atol=1e-6)
     assert np.allclose(np.linalg.norm(b_new), 1.0, atol=1e-6)
     assert abs(np.dot(a_rot, b_new)) < 1e-6
-    assert np.allclose(a_rot, np.array([0.0, 0.0, 1.0, 0.0], dtype=np.float32), atol=1e-6)
+    assert np.allclose(a_rot, axis, atol=1e-6)
+    assert np.allclose(b_new, b, atol=1e-6)


### PR DESCRIPTION
## Summary
- add `rotate_plane_4d` to rotate vectors inside an arbitrary 4D plane
- map pixel grids to 4D positions via `sample_slice_image` and evaluate a basic field for real slice images
- update tests to validate 4D rotation logic

## Testing
- `pip install -r requirements.txt`
- `pytest`
- `python dashifine/Main_with_rotation.py --output_dir examples`

------
https://chatgpt.com/codex/tasks/task_e_68ae953c133c83229fbd675a2133a84a