### PR TITLE
Add CMY color mixing and opacity compositing

### DIFF
--- a/dashifine/Main_with_rotation.py
+++ b/dashifine/Main_with_rotation.py
@@ -31,6 +31,37 @@ def rotate_plane(o: np.ndarray, a: np.ndarray, b: np.ndarray, axis: np.ndarray, 
     return o, a_rot, b_new
 
 
+def mix_cmy_to_rgb(weights: np.ndarray) -> np.ndarray:
+    """Mix the first three channels (CMY) and convert to RGB.
+
+    Parameters
+    ----------
+    weights:
+        Array of shape ``(..., 4)`` containing CMYK weights in ``[0, 1]``.
+
+    Returns
+    -------
+    np.ndarray
+        RGB image in ``[0, 1]``.
+    """
+    cmy = np.clip(weights[..., :3], 0.0, 1.0)
+    k = np.clip(weights[..., 3:4], 0.0, 1.0)
+    rgb = (1.0 - cmy) * (1.0 - k)
+    return np.clip(rgb, 0.0, 1.0)
+
+
+def density_to_alpha(density: np.ndarray, beta: float = 1.5) -> np.ndarray:
+    """Map density values to opacity using ``density ** beta``."""
+    density = np.clip(density, 0.0, 1.0)
+    return np.power(density, beta)
+
+
+def composite_rgb_alpha(rgb: np.ndarray, alpha: np.ndarray, bg: Tuple[float, float, float] = (1.0, 1.0, 1.0)) -> np.ndarray:
+    """Composite an RGB image against a background using the supplied alpha."""
+    bg_arr = np.asarray(bg, dtype=np.float32)
+    return rgb * alpha[..., None] + bg_arr * (1.0 - alpha[..., None])
+
+
 def main(
     output_dir: str | Path,
     res_hi: int = 64,
@@ -39,21 +70,35 @@ def main(
     z0_steps: int = 1,
     w0_steps: int = 1,
     slopes: np.ndarray | None = None,
+    opacity_exp: float = 1.5,
 ) -> Dict[str, Any]:
-    """Generate placeholder slices and return their file paths."""
+    """Generate example slices and return their file paths."""
     out_dir = Path(output_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
-
-    density = np.zeros((res_coarse, res_coarse), dtype=np.float32)
+    # Generate coarse density for reference
+    x = np.linspace(0.0, 1.0, res_coarse, dtype=np.float32)
+    y = np.linspace(0.0, 1.0, res_coarse, dtype=np.float32)
+    Xc, Yc = np.meshgrid(x, y)
+    weights_coarse = np.stack([Xc, Yc, 1.0 - Xc, 0.5 * np.ones_like(Xc)], axis=-1)
+    density = weights_coarse.mean(axis=-1)
     density_path = out_dir / "coarse_density_map.png"
     plt.imsave(density_path, density, cmap="gray")
 
-    origin = np.zeros((res_hi, res_hi, 3), dtype=np.float32)
+    # High-resolution origin slice
+    xh = np.linspace(0.0, 1.0, res_hi, dtype=np.float32)
+    yh = np.linspace(0.0, 1.0, res_hi, dtype=np.float32)
+    Xh, Yh = np.meshgrid(xh, yh)
+    weights_hi = np.stack([Xh, Yh, 1.0 - Xh, 0.5 * np.ones_like(Xh)], axis=-1)
+    rgb = mix_cmy_to_rgb(weights_hi)
+    density_hi = weights_hi.mean(axis=-1)
+    alpha = density_to_alpha(density_hi, opacity_exp)
+    origin = composite_rgb_alpha(rgb, alpha)
     origin_path = out_dir / "slice_origin.png"
     plt.imsave(origin_path, origin)
 
     paths = {"origin": str(origin_path), "coarse_density": str(density_path)}
 
+    # Generate rotated slices (placeholder using 90-degree rotations)
     o = np.zeros(4, dtype=np.float32)
     a = np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32)
     b = np.array([0.0, 1.0, 0.0, 0.0], dtype=np.float32)
@@ -62,7 +107,9 @@ def main(
     for i in range(num_rotated):
         angle = float(i) * 360.0 / max(num_rotated, 1)
         _o, _a, _b = rotate_plane(o, a, b, axis, angle)
-        img = np.zeros((res_hi, res_hi, 3), dtype=np.float32)
+        rgb_rot = np.rot90(rgb, k=i % 4, axes=(0, 1))
+        alpha_rot = np.rot90(alpha, k=i % 4, axes=(0, 1))
+        img = composite_rgb_alpha(rgb_rot, alpha_rot)
         rot_path = out_dir / f"slice_rot_{int(angle):+d}deg.png"
         plt.imsave(rot_path, img)
         paths[f"rot_{angle:+.1f}"] = str(rot_path)
@@ -76,6 +123,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--res_hi", type=int, default=64)
     parser.add_argument("--res_coarse", type=int, default=16)
     parser.add_argument("--num_rotated", type=int, default=1)
+    parser.add_argument("--opacity_exp", type=float, default=1.5)
     return parser.parse_args()
 
 
@@ -86,4 +134,5 @@ if __name__ == "__main__":
         res_hi=args.res_hi,
         res_coarse=args.res_coarse,
         num_rotated=args.num_rotated,
+        opacity_exp=args.opacity_exp,
     )


### PR DESCRIPTION
## Summary
- convert class weight CMY channels to RGB and composite with alpha
- map density to opacity with configurable exponent
- allow CLI control over opacity exponent

## Testing
- `pip install -r requirements.txt`
- `python dashifine/Main_with_rotation.py --output_dir examples`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae953c755083229d9c9f8104c2c26c