### PR TITLE
Add p-adic palette rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ python Main_with_rotation.py
 
 All output images are written to `/mnt/data`, including a coarse density map and PNG files for the origin slice and each rotation.
 
+### P-adic palette
+
+The `render` function accepts two 2D arrays per pixel:
+
+* `addresses` – integer p-adic addresses.
+* `depth` – floating-point depth values.
+
+Setting `palette="p_adic"` maps `addresses` to hue and `depth` to saturation,
+producing an RGB image via HSV conversion.
+
 ## Configuration
 `Main_with_rotation.py` exposes several constants at the top of the file that control behavior, such as:
 

--- a/dashifine/Main_with_rotation.py
+++ b/dashifine/Main_with_rotation.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Tuple, Dict, Any
 
 import matplotlib.pyplot as plt
+from matplotlib.colors import hsv_to_rgb
 import numpy as np
 
 
@@ -29,6 +30,75 @@ def rotate_plane(o: np.ndarray, a: np.ndarray, b: np.ndarray, axis: np.ndarray, 
     a_rot = a * np.cos(angle) + axis * np.sin(angle)
     b_new = b / np.linalg.norm(b)
     return o, a_rot, b_new
+
+
+def p_adic_address_to_hue_saturation(
+    addresses: np.ndarray, depth: np.ndarray, base: int = 2
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Map p-adic addresses to hue and depth to saturation.
+
+    Parameters
+    ----------
+    addresses:
+        Integer array giving the p-adic address for each pixel.
+    depth:
+        Float array giving the depth for each pixel.
+    base:
+        Base ``p`` of the p-adic numbers.
+
+    Returns
+    -------
+    hue, saturation : tuple[np.ndarray, np.ndarray]
+        Normalised hue and saturation arrays in ``[0, 1]``.
+    """
+
+    addresses = addresses.astype(np.int64)
+    depth = depth.astype(np.float32)
+    if addresses.size == 0:
+        return (
+            np.empty_like(addresses, dtype=np.float32),
+            np.empty_like(depth, dtype=np.float32),
+        )
+
+    max_power = int(np.ceil(np.log(addresses.max() + 1) / np.log(base)))
+    hue = np.zeros_like(addresses, dtype=np.float32)
+    for k in range(max_power):
+        digit = (addresses // (base ** k)) % base
+        hue += digit / (base ** (k + 1))
+
+    saturation = (
+        depth / (np.max(depth) + 1e-8) if np.any(depth) else np.zeros_like(depth)
+    )
+    return hue, saturation
+
+
+def render(
+    addresses: np.ndarray,
+    depth: np.ndarray,
+    *,
+    palette: str = "gray",
+    base: int = 2,
+) -> np.ndarray:
+    """Render an RGB image from ``addresses`` and ``depth``.
+
+    ``addresses`` and ``depth`` supply per-pixel p-adic addresses and depth
+    values respectively. When ``palette='p_adic'`` the addresses determine the
+    hue and the depth controls saturation. Other palettes fall back to a simple
+    grayscale mapping of ``depth``.
+
+    Returns
+    -------
+    np.ndarray
+        RGB image with values in ``[0, 1]``.
+    """
+
+    if palette == "p_adic":
+        hue, sat = p_adic_address_to_hue_saturation(addresses, depth, base)
+        hsv = np.stack([hue, sat, np.ones_like(hue)], axis=-1)
+        return hsv_to_rgb(hsv)
+
+    value = depth / (np.max(depth) + 1e-8) if np.any(depth) else np.zeros_like(depth)
+    return np.stack([value, value, value], axis=-1)
 
 
 def main(

--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -1,6 +1,7 @@
 import numpy as np
 from pathlib import Path
 import sys
+from matplotlib.colors import hsv_to_rgb
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -9,6 +10,8 @@ from dashifine.Main_with_rotation import (
     main,
     orthonormalize,
     rotate_plane,
+    render,
+    p_adic_address_to_hue_saturation,
 )
 
 
@@ -35,3 +38,14 @@ def test_rotate_plane_produces_orthonormal():
     assert np.allclose(np.linalg.norm(b_new), 1.0, atol=1e-6)
     assert abs(np.dot(a_rot, b_new)) < 1e-6
     assert np.allclose(a_rot, np.array([0.0, 0.0, 1.0, 0.0], dtype=np.float32), atol=1e-6)
+
+
+def test_p_adic_palette_maps_address_and_depth():
+    addresses = np.array([[0, 1], [2, 3]], dtype=np.int64)
+    depth = np.array([[0.0, 1.0], [2.0, 3.0]], dtype=np.float32)
+    rgb = render(addresses, depth, palette="p_adic", base=4)
+
+    hue, sat = p_adic_address_to_hue_saturation(addresses, depth, base=4)
+    hsv = np.stack([hue, sat, np.ones_like(hue)], axis=-1)
+    expected = hsv_to_rgb(hsv)
+    assert np.allclose(rgb, expected)


### PR DESCRIPTION
## Summary
- map p-adic addresses to hue and depth to saturation
- expose `palette="p_adic"` option in `render`
- document per-pixel address and depth inputs

## Testing
- `pip install -r requirements.txt`
- `python dashifine/Main_with_rotation.py --output_dir examples`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae953d02a08322b0aa3c974be97613