### PR TITLE
Render class weights with density-based alpha

### DIFF
--- a/dashifine/Main_with_rotation.py
+++ b/dashifine/Main_with_rotation.py
@@ -57,6 +57,47 @@ def orthonormalize(a: np.ndarray, b: np.ndarray, eps: float = 1e-8) -> Tuple[np.
     return a, b
 
 
+def rotate_plane(
+    o: np.ndarray,
+    a: np.ndarray,
+    b: np.ndarray,
+    axis_perp: np.ndarray,
+    angle_deg: float,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Rotate a 2D plane within 4D space around ``axis_perp``.
+
+    The basis vectors ``a`` and ``b`` spanning the plane are first
+    orthonormalised.  The component of ``axis_perp`` orthogonal to this plane
+    defines the rotation axis.  The plane is then rotated by ``angle_deg``
+    degrees around this axis.
+
+    Parameters
+    ----------
+    o : np.ndarray
+        Origin of the slice plane.
+    a, b : np.ndarray
+        Basis vectors spanning the plane.
+    axis_perp : np.ndarray
+        Vector defining the rotation axis (need not be normalised).
+    angle_deg : float
+        Rotation angle in degrees.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray, np.ndarray]
+        The unchanged origin and the rotated basis vectors ``a`` and ``b``.
+    """
+
+    a1, b1 = orthonormalize(a, b)
+    n = axis_perp.astype(np.float32)
+    n = n - (n @ a1) * a1 - (n @ b1) * b1
+    n /= np.linalg.norm(n) + 1e-8
+    theta = np.deg2rad(angle_deg).astype(np.float32)
+    a_rot = np.cos(theta) * a1 + np.sin(theta) * n
+    a_rot, b_new = orthonormalize(a_rot, b1)
+    return o, a_rot, b_new
+
+
 def rotate_plane_4d(
     o: np.ndarray,
     a: np.ndarray,
@@ -174,6 +215,41 @@ def composite_rgb_alpha(rgb: np.ndarray, alpha: np.ndarray, bg: Tuple[float, flo
     """Composite an RGB image against a background using the supplied alpha."""
     bg_arr = np.asarray(bg, dtype=np.float32)
     return rgb * alpha[..., None] + bg_arr * (1.0 - alpha[..., None])
+
+
+def class_weights_to_rgba(
+    class_weights: np.ndarray,
+    density: np.ndarray,
+    beta: float = 1.5,
+) -> np.ndarray:
+    """Map class weights and density to a composited RGB image.
+
+    The first three channels of ``class_weights`` are interpreted as CMY
+    contributions.  A zero ``K`` channel is appended and the result converted to
+    RGB.  Opacity is computed as ``density ** beta`` and the RGB image is
+    composited over a white background.
+
+    Parameters
+    ----------
+    class_weights:
+        Array of shape ``(H, W, C)`` with ``C >= 3`` containing per-class
+        weights.
+    density:
+        Array of shape ``(H, W)`` giving normalised density ``rho_tilde``.
+    beta:
+        Exponent controlling opacity from density.
+
+    Returns
+    -------
+    np.ndarray
+        Composited RGB image in ``[0, 1]``.
+    """
+
+    k = np.zeros(class_weights.shape[:2] + (1,), dtype=class_weights.dtype)
+    weights = np.concatenate([class_weights[..., :3], k], axis=-1)
+    rgb = mix_cmy_to_rgb(weights)
+    alpha = density_to_alpha(density, beta)
+    return composite_rgb_alpha(rgb, alpha)
 
 
 def p_adic_address_to_hue_saturation(
@@ -388,6 +464,10 @@ def main(
 
     tau = margin_temperature(F)
     class_weights = softmax(F / tau, axis=-1)
+    class_img = class_weights_to_rgba(class_weights, density, opacity_exp)
+    class_path = out_dir / "class_weights_composite.png"
+    plt.imsave(class_path, class_img)
+    paths["class_weights"] = str(class_path)
 
     return {"paths": paths, "density": density, "class_weights": class_weights}
 

--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -9,10 +9,11 @@ from dashifine.Main_with_rotation import (
     gelu,
     main,
     orthonormalize,
-    rotate_plane,
     render,
     p_adic_address_to_hue_saturation,
     rotate_plane_4d,
+    rotate_plane,
+    class_weights_to_rgba,
 )
 
 
@@ -50,5 +51,22 @@ def test_p_adic_palette_maps_address_and_depth():
     hsv = np.stack([hue, sat, np.ones_like(hue)], axis=-1)
     expected = hsv_to_rgb(hsv)
     assert np.allclose(rgb, expected)
+
+
+def test_rotate_plane_rotates_basis():
+    o = np.zeros(4, dtype=np.float32)
+    a = np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32)
+    b = np.array([0.0, 1.0, 0.0, 0.0], dtype=np.float32)
+    axis = np.array([0.0, 0.0, 1.0, 0.0], dtype=np.float32)
+    _, a_rot, b_new = rotate_plane(o, a, b, axis, 90.0)
     assert np.allclose(a_rot, axis, atol=1e-6)
     assert np.allclose(b_new, b, atol=1e-6)
+
+
+def test_class_weights_to_rgba_fades_low_density():
+    weights = np.array([[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]], dtype=np.float32)
+    density = np.array([[1.0, 0.0]], dtype=np.float32)
+    img = class_weights_to_rgba(weights, density, beta=1.0)
+    assert np.allclose(img[0, 0], np.array([0.0, 1.0, 1.0]), atol=1e-6)
+    assert np.allclose(img[0, 1], np.ones(3), atol=1e-6)
+


### PR DESCRIPTION
## Summary
- add 4D plane rotation helper and class-weight compositing utility
- convert class weights to RGB and blend using density-derived alpha
- verify transparency behaviour with new unit tests

## Testing
- `pip install -r requirements.txt`
- `python dashifine/Main_with_rotation.py --output_dir examples`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae98a07e208322aea557671e15e58b