### PR TITLE
docs: add manual QA checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,15 @@ Sample output from a run of `Main_with_rotation.py`:
 
 ---
 
+## Manual QA
+
+Use this checklist to verify the renderer behaves as expected:
+
+- [ ] Run `python Main_with_rotation.py --output_dir examples --num_rotated 8` and confirm successive PNGs differ.
+- [ ] Verify translucent voids appear in low-density regions.
+- [ ] Place two centers close together to observe blended colours; separated centers yield crisp hues.
+- [ ] Expect CM/CMY primary colours for the three classes: cyan, magenta and yellow.
+
 Why not just use float32 everywhere?
 
 Because the space of possible slices is huge. Even in 4D:


### PR DESCRIPTION
## Summary
- document manual QA steps for verifying slice rendering and colour behaviour

## Testing
- `pip install -r requirements.txt`
- `python dashifine/Main_with_rotation.py --output_dir examples` *(fails: NameError: name 'rotate_plane' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ae98a5664083229d5bf03d328e403b