### PR TITLE
Composite slice rendering

### DIFF
--- a/PATCH_DROPIN_SUGGESTED.py
+++ b/PATCH_DROPIN_SUGGESTED.py
@@ -1,6 +1,6 @@
 import argparse
 from pathlib import Path
-from typing import Tuple, Dict, Any, List
+from typing import Tuple, Dict, Any, List, Sequence
 
 import matplotlib.pyplot as plt
 from matplotlib.colors import hsv_to_rgb
@@ -252,8 +252,43 @@ def sample_slice_points(H: int, W: int, origin4: np.ndarray, a4: np.ndarray, b4:
     pts = origin4[None, :] + scale * (U.reshape(-1, 1) * a4[None, :] + V.reshape(-1, 1) * b4[None, :])
     return pts  # (HW,4)
 
-def render_slice(H: int, W: int, origin4: np.ndarray, a4: np.ndarray, b4: np.ndarray,
-                 centers: List[Dict[str, np.ndarray]], V: np.ndarray, palette: str = "cmy") -> Tuple[np.ndarray, np.ndarray]:
+def render_slice(
+    H: int,
+    W: int,
+    origin4: np.ndarray,
+    a4: np.ndarray,
+    b4: np.ndarray,
+    centers: List[Dict[str, np.ndarray]],
+    V: np.ndarray,
+    palette: str = "cmy",
+    bg: Sequence[float] | np.ndarray = np.ones(3, dtype=np.float32),
+    beta: float = 1.5,
+) -> np.ndarray:
+    """Render a single slice and composite against ``bg``.
+
+    Parameters
+    ----------
+    H, W:
+        Output image height and width.
+    origin4, a4, b4:
+        Slice origin and basis vectors in 4D.
+    centers:
+        List of centre dictionaries defining the field.
+    V:
+        Class loading matrix.
+    palette:
+        Colour mapping strategy (``"cmy"``, ``"eigen"``, ``"lineage"``).
+    bg:
+        RGB background colour to composite over.
+    beta:
+        Opacity exponent ``α = ρ̃^β``.
+
+    Returns
+    -------
+    np.ndarray
+        Composited RGB image of shape ``(H, W, 3)``.
+    """
+
     pts = sample_slice_points(H, W, origin4, a4, b4, scale=1.0)
     rho, F = field_and_classes(pts, centers, V)
 
@@ -264,10 +299,12 @@ def render_slice(H: int, W: int, origin4: np.ndarray, a4: np.ndarray, b4: np.nda
         tau = temperature_from_margin(F[i])
         Wc[i] = softmax(F[i], tau=tau)
 
-    if palette.lower() == "cmy" and C >= 3:
-        RGB = cmy_from_weights(Wc[:, :3]).reshape(H, W, 3)
+    if palette.lower() == "cmy":
+        CMY = np.zeros((Wc.shape[0], 3), dtype=np.float32)
+        CMY[:, : min(3, C)] = np.clip(Wc[:, : min(3, C)], 0.0, 1.0)
+        rgb = 1.0 - CMY
     elif palette.lower() == "eigen":
-        RGB = eigen_palette(Wc).reshape(H, W, 3)
+        rgb = eigen_palette(Wc)
     elif palette.lower() == "lineage":
         top_idx = np.argmax(Wc, axis=1)
         depth = np.max(Wc, axis=1)
@@ -277,19 +314,22 @@ def render_slice(H: int, W: int, origin4: np.ndarray, a4: np.ndarray, b4: np.nda
             addr = f"{int(idx)}.{int(d_clip * 1000):03d}"
             h, s, v = lineage_hue_from_address(addr)
             hsv[i] = [h, s, v]
-        RGB = hsv_to_rgb(hsv).reshape(H, W, 3)
+        rgb = hsv_to_rgb(hsv)
     else:
-        # 2-class CM (Cyan/Magenta) or generic grayscale fallback
         if C >= 2:
-            CM = np.clip(Wc[:, :2], 0, 1)  # [C,M]
-            # fill Y=0, make 3 channels CMY -> RGB
-            CMY = np.concatenate([CM, np.zeros((Wc.shape[0], 1), dtype=np.float32)], axis=1)
-            RGB = (1.0 - CMY).reshape(H, W, 3)
+            CM = np.clip(Wc[:, :2], 0, 1)
+            CMY = np.concatenate(
+                [CM, np.zeros((Wc.shape[0], 1), dtype=np.float32)], axis=1
+            )
+            rgb = 1.0 - CMY
         else:
-            RGB = np.repeat(np.max(Wc, axis=1).reshape(H, W, 1), 3, axis=2)
+            rgb = np.repeat(np.max(Wc, axis=1).reshape(-1, 1), 3, axis=1)
 
-    A = opacity_from_density(rho).reshape(H, W, 1)
-    return np.clip(RGB, 0, 1), A
+    rgb = rgb.reshape(H, W, 3)
+    alpha = opacity_from_density(rho, beta=beta).reshape(H, W, 1)
+    bg_arr = np.array(bg, dtype=np.float32).reshape(1, 1, 3)
+    img = np.clip(rgb * alpha + bg_arr * (1.0 - alpha), 0.0, 1.0)
+    return img
 
 
 # ------------------------------------ main -----------------------------------
@@ -344,20 +384,22 @@ def main(
         o_t[3] = float(t) / max(num_time - 1, 1)
 
         # origin slice for this time step
-        img0, A0 = render_slice(res_hi, res_hi, o_t, a, b, centers, V, palette=palette)
-        rgba0 = np.clip(np.dstack([img0, A0]), 0, 1)
+        img0 = render_slice(
+            res_hi, res_hi, o_t, a, b, centers, V, palette=palette
+        )
         origin_path = out_dir / f"slice_t{t}_origin.png"
-        plt.imsave(origin_path, rgba0)
+        plt.imsave(origin_path, img0)
         paths[f"t{t}_origin"] = str(origin_path)
 
         # rotated slices for this time step
         for i in range(num_rotated):
             angle = float(i) * 360.0 / max(num_rotated, 1)
             a_rot, b_rot = rotate_plane_4d(a, b, u, v, np.deg2rad(angle))
-            img, A = render_slice(res_hi, res_hi, o_t, a_rot, b_rot, centers, V, palette=palette)
-            rgba = np.clip(np.dstack([img, A]), 0, 1)
+            img = render_slice(
+                res_hi, res_hi, o_t, a_rot, b_rot, centers, V, palette=palette
+            )
             rot_path = out_dir / f"slice_t{t}_rot_{int(angle):+d}deg.png"
-            plt.imsave(rot_path, rgba)
+            plt.imsave(rot_path, img)
             paths[f"t{t}_rot_{angle:+.1f}"] = str(rot_path)
 
     paths["coarse_density"] = str(density_path)

--- a/tests/test_lineage_palette.py
+++ b/tests/test_lineage_palette.py
@@ -30,7 +30,18 @@ def test_render_slice_lineage_palette_matches_hsv_mapping():
     centers = [{"mu": origin, "sigma": np.ones(4, dtype=np.float32), "w": 1.0}]
     V = np.eye(1, dtype=np.float32)
 
-    rgb, _ = render_slice(H, W, origin, a, b, centers, V, palette="lineage")
+    rgb = render_slice(
+        H,
+        W,
+        origin,
+        a,
+        b,
+        centers,
+        V,
+        palette="lineage",
+        bg=np.zeros(3, dtype=np.float32),
+        beta=0.0,
+    )
 
     pts = sample_slice_points(H, W, origin, a, b)
     rho, F = field_and_classes(pts, centers, V)


### PR DESCRIPTION
## Summary
- Composite slice rendering by converting class weights to CMY→RGB and alpha blending against a background
- Adjust main rendering pipeline to output RGB images only
- Update lineage palette test for new render_slice API

## Testing
- `pip install -r requirements.txt`
- `python dashifine/Main_with_rotation.py --output_dir examples` *(fails: SyntaxError: unmatched ')')*
- `pytest` *(fails: SyntaxError: unmatched ')')*
- `pytest tests/test_lineage_palette.py`


------
https://chatgpt.com/codex/tasks/task_e_68aefbb69c1483228127784e6666d7dd