### PR TITLE
docs: describe palette options and QA steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,22 @@ All output images are written to `/mnt/data`, including a coarse density map and
 `PATCH_DROPIN_SUGGESTED.py` also supports temporal rendering.  Passing `--num_time N` steps the slice origin through N normalised
 time values (0 to 1), writing files like `slice_t0_rot_0deg.png` for each time step and rotation.
 
+### Palette options
+
+Use `--palette` to choose how class weights map to colour:
+
+* `cmy` (default) – map the first three classes to cyan, magenta and yellow.
+* `eigen` – visualise weights via the leading eigenvectors (grayscale placeholder).
+* `lineage` – assign hues by lineage using an HSV mapping.
+
+Example commands:
+
+```bash
+python Main_with_rotation.py --output_dir examples --palette cmy
+python Main_with_rotation.py --output_dir examples --palette eigen
+python Main_with_rotation.py --output_dir examples --palette lineage
+```
+
 ### P-adic palette
 
 The `render` function accepts two 2D arrays per pixel:
@@ -138,10 +154,9 @@ Sample output from a run of `Main_with_rotation.py`:
 
 Use this checklist to verify the renderer behaves as expected:
 
-- [ ] Run `python Main_with_rotation.py --output_dir examples --num_rotated 8` and confirm successive PNGs differ.
-- [ ] Verify translucent voids appear in low-density regions.
-- [ ] Place two centers close together to observe blended colours; separated centers yield crisp hues.
-- [ ] Expect CM/CMY primary colours for the three classes: cyan, magenta and yellow.
+- [ ] Run `python Main_with_rotation.py --output_dir examples --num_rotated 8` and confirm images change with angle.
+- [ ] Verify low-density regions fade transparent ("inverse Swiss cheese").
+- [ ] Move centres to see soft vs. crisp class boundaries.
 
 Why not just use float32 everywhere?
 


### PR DESCRIPTION
## Summary
- document `--palette` choices and example commands
- update manual QA checklist for verifying rotation, transparency, and boundary sharpness

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: SyntaxError: unmatched ')')*
- `python dashifine/Main_with_rotation.py --output_dir examples` *(fails: SyntaxError: unmatched ')')*

------
https://chatgpt.com/codex/tasks/task_e_68aefbba30c08322a57a1fec5003591e